### PR TITLE
Fix misplaced quotes

### DIFF
--- a/roles/scripts/templates/manageUserDirs.py.j2
+++ b/roles/scripts/templates/manageUserDirs.py.j2
@@ -503,9 +503,9 @@ class MoveJob(Base):
                     etag_before = self.db.getEtag(user)
                     self.logger.debug("Etag before: " + str(etag_before))
                     command = "/usr/bin/ssh " + source_server \
-                        + " /bin/tar -C '" + source_root_dir \
+                        + " /bin/tar -C '" + source_root_dir + "'" \
                         + " -b 1024" \
-                        + "' -cf - '" + user + "' | "
+                        + " -cf - '" + user + "' | "
                     if target_server != source_server:
                         command = command + "/usr/bin/ssh " + target_server + " "
                     command = command + "/bin/tar -xf -" \


### PR DESCRIPTION
When I added the `-b 1024` option to the `tar` commands (#5), I introduced an error in the first `tar`: I included the ` -b 1024` _within_ the single-quoted `-C` argument.  This commit should fix that.