### PR TITLE
Added more patches to solve timeouts for WebDAV put()s

### DIFF
--- a/roles/ocphp_fpm_image/files/ocphp_fpm/patches/storagefix/reconnect-after-assemble.patch
+++ b/roles/ocphp_fpm_image/files/ocphp_fpm/patches/storagefix/reconnect-after-assemble.patch
@@ -1,8 +1,56 @@
 diff --git a/apps/dav/lib/connector/sabre/file.php b/apps/dav/lib/connector/sabre/file.php
-index 59b3a6e..b7493bc 100644
+index 59b3a6e748..d0bac96c61 100644
 --- a/apps/dav/lib/connector/sabre/file.php
 +++ b/apps/dav/lib/connector/sabre/file.php
-@@ -435,6 +435,13 @@ class File extends Node implements IFile {
+@@ -85,6 +85,10 @@ class File extends Node implements IFile {
+ 	 * @return string|null
+ 	 */
+ 	public function put($data) {
++
++        $start_microtime = microtime(true);
++        $db_check_interval = 300;
++
+ 		try {
+ 			$exists = $this->fileView->file_exists($this->path);
+ 			if ($this->info && $exists && !$this->info->isUpdateable()) {
+@@ -158,12 +162,30 @@ class File extends Node implements IFile {
+ 		}
+ 
+ 		try {
+-			$view = \OC\Files\Filesystem::getView();
+-			if ($view) {
+-				$run = $this->emitPreHooks($exists);
+-			} else {
+-				$run = true;
+-			}
++			try {
++                if ((microtime(true) - $start_microtime) >= $interval*1e6) {
++                    $conn = \OC::$server->getDatabaseConnection();
++                    if ($conn->ping() === false) {
++                        if ( ! $conn->inTransaction() ) {
++                            throw new Exception('A long WebDAV upload caused the database connection to timeout during a transaction. Try increasing the database connection timeout.');
++                        }
++                        $conn->close();
++                        $conn->connect();
++                    }
++                }
++
++                $view = \OC\Files\Filesystem::getView();
++                if ($view) {
++                    $run = $this->emitPreHooks($exists);
++                } else {
++                    $run = true;
++                }
++            } catch (\Exception $e) {
++                if ($needsPartFile) {
++                    $partStorage->unlink($internalPartPath);
++                }
++                $this->convertToSabreException($e);
++            }
+ 
+ 			try {
+ 				$this->changeLock(ILockingProvider::LOCK_EXCLUSIVE);
+@@ -435,6 +457,13 @@ class File extends Node implements IFile {
  
  					$chunk_handler->file_assemble($partStorage, $partInternalPath, $this->fileView->getAbsolutePath($targetPath));
  


### PR DESCRIPTION
The existing patch to sable/file.php has been extended based on two commits I added to our version:

* [improve error handling](https://github.com/sleinen/core/commit/1dd1d2b525bc595b418e7fa7c5e7dc42515516e1)
* [check and possibly reopen DB connection](https://github.com/sleinen/core/commit/0f6740d77957668e0a35a85ecb20221cd65b5ae4)

Note that this hasn't been tested.  Probably we should make a container image from this branch, and test that in SWITCHdrive's staging environment.  We'd need a test case to verify whether it helps.  So far this particular issue has occurred only (or primarily) with Synology NAS systems' WebDAV-based backup mechanism.  Do we need to buy such a box for testing?